### PR TITLE
multidecoder pretraining

### DIFF
--- a/egs/must_c/st1/conf/tuning/md/mdtrain-speechattn-asrinit.yaml
+++ b/egs/must_c/st1/conf/tuning/md/mdtrain-speechattn-asrinit.yaml
@@ -1,0 +1,75 @@
+# Trained on 4 16gb gpus (V-100)
+# For other gpu sizes and counts 
+# vary accum grad and batchsize accordingly
+# network architecture
+backend: pytorch
+model-module: "espnet.nets.pytorch_backend.e2e_st_md_transformer:E2E"
+transformer-lr: 12.5
+transformer-warmup-steps: 25000
+transformer-length-normalized-loss: false
+transformer-init: pytorch
+dropout-rate: 0.1
+
+# Loss Weighting
+mtlalpha: 0.3  # CTC weight
+asr-weight: 0.5  # ASR subnet weight
+lsm-weight: 0.1  # Label Smoothing
+
+# optimization related
+sortagrad: 0 # 0 disables Feed samples from shortest to longest
+opt: noam
+accum-grad: 3
+grad-clip: 5
+patience: 0
+epochs: 50
+
+# minibatch related
+batch-size: 32  # for BPE
+maxlen-in: 512  # if input length  > maxlen-in, batchsize is automatically reduced
+maxlen-out: 150 # if output length > maxlen-out, batchsize is automatically reduced
+
+# encoder asr related
+enc-inp-input-layer: conv2d
+enc-inp-layers: 12
+enc-inp-units: 2048
+enc-inp-aheads: 8
+enc-inp-adim: 512
+enc-inp-dropout-rate: 0.1
+enc-inp-transformer-attn-dropout-rate: 0.1
+
+
+# decoder asr related
+dec-si-layers: 6
+dec-si-units: 2048
+dec-si-aheads: 8
+dec-si-adim: 512
+dec-si-transformer-selfattn-layer-type: selfattn
+dec-si-dropout-rate: 0.1
+dec-si-transformer-attn-dropout-rate: 0.2
+
+# encoder st related
+enc-si-input-layer: nothing
+enc-si-layers: 4
+enc-si-units: 2048
+enc-si-aheads: 4
+enc-si-adim: 512
+enc-si-dropout-rate: 0.1
+enc-si-transformer-attn-dropout-rate: 0.1
+
+# decoder st related
+dec-out-layers: 6
+dec-out-units: 2048
+dec-out-aheads: 4
+dec-out-adim: 512
+dec-out-transformer-selfattn-layer-type: seqspeechattn
+dec-out-dropout-rate: 0.2
+dec-out-transformer-attn-dropout-rate: 0.4
+
+# pre-training related
+enc-init-mods: encoder_asr.embed,encoder_asr.encoders,encoder_asr.after_norm
+dec-init-mods: decoder_st.embed,decoder_st.decoders,decoder_st.after_norm,decoder_st.output_layer
+
+# Report CER & WER
+report-cer: true
+report-wer: true
+ctc_type: builtin

--- a/espnet/st/pytorch_backend/st.py
+++ b/espnet/st/pytorch_backend/st.py
@@ -25,6 +25,7 @@ from espnet.asr.asr_utils import torch_resume
 from espnet.asr.asr_utils import torch_snapshot
 from espnet.asr.pytorch_backend.asr_init import load_trained_model
 from espnet.asr.pytorch_backend.asr_init import load_trained_modules
+from espnet.asr.pytorch_backend.asr_init import load_trained_modules_for_multidecoder
 
 from espnet.nets.pytorch_backend.e2e_asr import pad_list
 from espnet.nets.st_interface import STInterface
@@ -133,7 +134,10 @@ def train(args):
 
     # Initialize with pre-trained ASR encoder and MT decoder
     if args.enc_init is not None or args.dec_init is not None:
-        model = load_trained_modules(idim, odim, args, interface=STInterface)
+        if args.model_module == "espnet.nets.pytorch_backend.e2e_st_md_transformer:E2E" or args.model_module == "espnet.nets.pytorch_backend.e2e_st_md_conformer:E2E":
+            model = load_trained_modules_for_multidecoder(idim, odim, args, interface=STInterface)
+        else:
+            model = load_trained_modules(idim, odim, args, interface=STInterface)
     else:
         model_class = dynamic_import(args.model_module)
         if "md" in str(model_class):

--- a/espnet/st/pytorch_backend/st.py
+++ b/espnet/st/pytorch_backend/st.py
@@ -134,9 +134,13 @@ def train(args):
 
     # Initialize with pre-trained ASR encoder and MT decoder
     if args.enc_init is not None or args.dec_init is not None:
-        if args.model_module == "espnet.nets.pytorch_backend.e2e_st_md_transformer:E2E" or args.model_module == "espnet.nets.pytorch_backend.e2e_st_md_conformer:E2E":
+        if "md" in args.model_module:
+            adim = args.enc_inp_adim
+            odim_si = int(valid_json[utts[0]]["output"][1]["shape"][-1])
+            logging.info("#input asr dims : " + str(odim_si))
             model = load_trained_modules_for_multidecoder(idim, odim, args, interface=STInterface)
         else:
+            adim = args.adim
             model = load_trained_modules(idim, odim, args, interface=STInterface)
     else:
         model_class = dynamic_import(args.model_module)


### PR DESCRIPTION
needed to rename asr and mt pretrained model_state keys to match multidecoder naming convention.